### PR TITLE
Remove incorrect IE quirk in HTMLElement.style docs

### DIFF
--- a/files/en-us/web/api/htmlelement/style/index.html
+++ b/files/en-us/web/api/htmlelement/style/index.html
@@ -40,7 +40,7 @@ tags:
 
 <p>Therefore, to add specific styles to an element without altering other style values, it is generally preferable to set individual properties on the {{domxref("CSSStyleDeclaration")}} object. For example, <code>element.style.backgroundColor = "red"</code>.</p>
 
-<p>A style declaration is reset by setting it to <code>null</code> or an empty string, e.g., <code>elt.style.color = null</code>. Internet Explorer requires setting it to an empty string, and does not do anything when setting it to <code>null</code>.</p>
+<p>A style declaration is reset by setting it to <code>null</code> or an empty string, e.g., <code>elt.style.color = null</code>.</p>
 
 <h3 id="Getting_style_information">Getting style information</h3>
 


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

The docs for HTMLElement.style say that setting fields to null in IE does nothing. I tested every major IE version all the way back to IE 6, and setting to null works to clear the value.

> Anything else that could help us review it

This is the code I used to test, by pasting in http://htmledit.squarefree.com/:

```
<div id="foo">hello</div>
<script>
var el = document.getElementById('foo');
el.style.fontSize = '55px';
el.style.fontSize = null;
</script>
```